### PR TITLE
Collapse node

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ export function App() {
   
   // handels the change of selected values (these in the box)
   const handleSelectedChange = (values) => {
-    console.log(values);
     const ids = values.map(value => symbolToIdMap.get(value));
     setSelectedValues(values); // Contains also already selected values
     setSelectedIds(ids); // update ids

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,8 @@
 
-import { Autocomplete, Loader, MultiSelect } from '@mantine/core';
+import { Loader, MultiSelect } from '@mantine/core';
 import React, { useState } from 'react';
 import { useAutocomplete } from './store/store';
 import { GeneGraph } from './GeneGraph';
-import { FilterNodeTypesArea } from './FilterNodeTypesArea';
 
 export function App() {
   const [selectedValues, setSelectedValues] = useState([]);
@@ -26,7 +25,7 @@ export function App() {
     setSearch(values);
   };
   const setIds = (ids: string[]) =>{
-    setSelectedIds([...selectedIds, ids])
+    setSelectedIds(ids)
   }
 
   return (
@@ -42,7 +41,7 @@ export function App() {
         rightSection={isFetching ? <Loader size="sm" /> : null}
       />
 
-      <GeneGraph geneID={selectedIds} addID={setIds}/>
+      <GeneGraph geneID={selectedIds} setIds={setIds}/>
     </>
   );
 }

--- a/src/GeneGraph.tsx
+++ b/src/GeneGraph.tsx
@@ -36,7 +36,6 @@ export function GeneGraph(props: GeneGraphProps) {
   });
 
   useMemo(() => {
-    
     (document as any).startViewTransition(() => {
       currentNodes = graph?.nodes.map((node,index)=>{
         return{

--- a/src/GeneGraph.tsx
+++ b/src/GeneGraph.tsx
@@ -6,7 +6,6 @@ import { nodeTypes } from "./NodeTypes";
 import FloatingEdge from './EdgeType';
 import FloatingConnectionLine from './FloatingConnectionLine';
 import { SidebarFilterList } from './SidebarFilterList';
-import { node } from 'execa';
 
 export const NodesContext = React.createContext(null)
 
@@ -17,7 +16,7 @@ const edgeTypes = {
 // Props for the GeneGraph component
 type GeneGraphProps = {
   geneID: string[]; // changed to array
-  addID;
+  setIds;
 };
 
 // GeneGraph component
@@ -28,7 +27,6 @@ export function GeneGraph(props: GeneGraphProps) {
   // state for the nodes and edges
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
-  const [currentGeneIds, setGeneIds] = useState(geneIds)
 
 
   // get all genes that are connected to the first node
@@ -37,7 +35,8 @@ export function GeneGraph(props: GeneGraphProps) {
     limit: 1000,
   });
 
-  useEffect(() => {
+  useMemo(() => {
+    
     (document as any).startViewTransition(() => {
       currentNodes = graph?.nodes.map((node,index)=>{
         return{
@@ -65,8 +64,6 @@ export function GeneGraph(props: GeneGraphProps) {
           type: "node"
         }});
       setNodes(currentNodes)
-        
-    
       
       setEdges(
         graph?.edges.map((edge) => ({
@@ -78,19 +75,17 @@ export function GeneGraph(props: GeneGraphProps) {
       );
 
     })
-
   }, [graph]);
 
   function exp(id: string){
     if(!geneIds.includes(id)){
       geneIds = ([...geneIds,id])
-      props.addID(id)
+      props.setIds(geneIds)
     }
   }
 
   function coll(id: string, children: [string]){
     geneIds = geneIds.filter(geneId => geneId != id)
-    setGeneIds(geneIds)
     currentNodes.forEach((child) => {
       child.data.parents = child.data.parents.filter((parent: string) => parent != id)})
       
@@ -98,15 +93,6 @@ export function GeneGraph(props: GeneGraphProps) {
     removeChildren = removeChildren.filter(node => node.data?.parents.length == 0)
     currentNodes = currentNodes.filter(node => !removeChildren.includes(node))
     setNodes(currentNodes)
-    // setNodes(nodes.filter(node => !removeChildIds.(node.id)))
-    // setNodes(nodes.filter(node => removeChildIds.forEach((...) => {}).includes(node.id)));
-    // node.childNodes.forEach(childId =>{
-    //   nodes.remov
-    // })
-    // if(geneIds.includes(id))
-    //   geneIds = geneIds.filter((f)=>f!==id)
-    // console.log(id);
-    // console.log(geneIds);
   }
 
   return (

--- a/src/NodeTypes.tsx
+++ b/src/NodeTypes.tsx
@@ -19,7 +19,7 @@ function DefaultCustomNode({ data }) {
     const reactflow = useReactFlow();
     const nodes = reactflow.getNodes();
     const nodeId = useNodeId();
-    const [collapsed, setCollapsed] = useState(true);
+    const [collapsed, setCollapsed] = useState(!data?.isRoot);
 
     const [nodeData, setNodeData] = useState(data?.displayProps);
 
@@ -37,10 +37,12 @@ function DefaultCustomNode({ data }) {
     function onExpandCollapse(){
         if(collapsed){
             data?.onExpand(nodeId)
-            setCollapsed(false);
+            setCollapsed(false)
         }
         else{
-
+            var realChildren = (data?.children).filter(childId => !data?.parents.includes(childId))
+            data?.onCollapse(nodeId, realChildren)
+            setCollapsed(true)
         }
     }
     

--- a/src/SidebarFilterList.tsx
+++ b/src/SidebarFilterList.tsx
@@ -86,7 +86,6 @@ export function SidebarFilterList() {
 
         const geneNodeLabels = nodes.map((node) => {
             if (node.data.type === 'gene') {
-                console.log(node.data.displayProps.label)
                 return node.data.displayProps.label
             }
         })
@@ -108,7 +107,6 @@ export function SidebarFilterList() {
                 <TreeView aria-aria-label='node tree' defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />}>
                     <TreeItem nodeId='listNodeGene' label='genes'>
                         {geneNodeLabels.map((label) => {
-                            console.log(label)
                             return <TreeItem nodeId={label + "_treeItem"} label={label}/>
                         })}
                     </TreeItem>


### PR DESCRIPTION
changed "addID" to "setIDs"
removed unused imports & console.log
added currentNodes to GeneGraph
setting parents & children when adding a node

expanded nodes can be collapsed (and first node is also marked as already expanded)